### PR TITLE
Fix automatic creation of #playSound element

### DIFF
--- a/README
+++ b/README
@@ -2,10 +2,6 @@
 
 This plugin defines $.playSound function.
 
-HTML:
-  Define an element with id "playSound" somewhere in body. Most likely, invisible.
-
-Javascript:
   $.playSound('http://example.org/sound.mp3');
 
 That's all folks!

--- a/jquery.playSound.js
+++ b/jquery.playSound.js
@@ -6,7 +6,9 @@
 */
 
 (function($){
-  $('body').append('<span id="playSound"></span>');
+  $(document).ready(function() {
+      $('body').append('<span id="playSound"></span>');
+  });
 
   $.extend({
     playSound: function(){


### PR DESCRIPTION
By placing the code that appends the `#playSound` element inside a
`$(document).ready()` function, it correctly runs at the right time and
adds the element as expected.
