### PR TITLE
Allow multiple sounds to be played simultaneously

### DIFF
--- a/jquery.playSound.js
+++ b/jquery.playSound.js
@@ -10,7 +10,7 @@
 
   $.extend({
     playSound: function(){
-      $('#playSound').html("<embed src='"+arguments[0]+"' hidden='true' autostart='true' loop='false'>");
+      $('#playSound').append("<embed src='"+arguments[0]+"' hidden='true' autostart='true' loop='false'>");
     }
   });
 


### PR DESCRIPTION
By using `.append()` rather than `.html()`, `<embed>` elements get added
sequentially to the `#playSound` element rather than overwriting the
existing element. This allows multiple sounds to be played over each
other.
