### PR TITLE
More convenient

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 This plugin defines $.playSound function.
 ```
-  $.playSound('http://example.org/sound');
+ $.playSound('http://example.org/sound')
+ $.playSound('http://example.org/sound.wav')
+ $.playSound('/attachments/sounds/1234.wav')
+ $.playSound('/attachments/sounds/1234.mp3')
+ 
+ //Stop Sound
+ $.stopSound();
 ```
 Demo: https://jsfiddle.net/admsev/xscxya0g/
 
-Important: Do not add file extension like `.mp3` or `.ogg` - browser does it automagically.
+Enjoy it!
 
 That's all folks!

--- a/jquery.playSound.js
+++ b/jquery.playSound.js
@@ -2,21 +2,25 @@
  * @author Alexander Manzyuk <admsev@gmail.com>
  * Copyright (c) 2012 Alexander Manzyuk - released under MIT License
  * https://github.com/admsev/jquery-play-sound
- * Usage: $.playSound('http://example.org/sound');
+ * Usage: $.playSound('http://example.org/sound')
+ * $.playSound('http://example.org/sound.wav')
+ * $.playSound('/attachments/sounds/1234.wav')
+ * $.playSound('/attachments/sounds/1234.mp3')
+ * $.stopSound();
 **/
 
-(function($){
-
-  $.extend({
-    playSound: function(){
-      return $(
-        '<audio autoplay="autoplay" style="display:none;">'
-          + '<source src="' + arguments[0] + '.mp3" />'
-          + '<source src="' + arguments[0] + '.ogg" />'
-          + '<embed src="' + arguments[0] + '.mp3" hidden="true" autostart="true" loop="false" class="playSound" />'
-        + '</audio>'
-      ).appendTo('body');
-    }
-  });
-
+(function ($) {
+    $.extend({
+        playSound: function () {
+            return $(
+                   '<audio class="sound-player" autoplay="autoplay" style="display:none;">'
+                     + '<source src="' + arguments[0] + '" />'
+                     + '<embed src="' + arguments[0] + '" hidden="true" autostart="true" loop="false"/>'
+                   + '</audio>'
+                 ).appendTo('body');
+        },
+        stopSound: function () {
+            $(".sound-player").remove();
+        }
+    });
 })(jQuery);


### PR DESCRIPTION
In my case, 

1, I need to play wav files;
2, sound.mp3 and sound.wav can be in same folder.
3, I have another API to get sound, I need attachementId, not file name and extension.

In order to do them, extension should be specified.
